### PR TITLE
Support \n, \l (newline left justified), \r (newline right justtified…) and \\

### DIFF
--- a/src/DotParser/Grammar.yrd
+++ b/src/DotParser/Grammar.yrd
@@ -32,7 +32,7 @@ graph: g=graph_type [ID] LBRACE g1=stmt_list<<g>> RBRACE { g1 }
 graph_type: s=[STRICT] d=(GRAPH { false } | DIGRAPH { true }) { emptyGraph d (isSome s) }
 
 stmt_list<<(g: GraphData)>>:
-    g1=[s=stmt<<g>> [SEMI] s1=[stmt_list<<s>>] { getOrElse s s1 }] { getOrElse g g1 }
+    g1=[s=stmt<<g>> s1=[stmt_list<<s>>] { getOrElse s s1 }] { getOrElse g g1 }
 
 stmt<<(g: GraphData)>>:
     g1=node_stmt<<g>> { g1 }
@@ -48,7 +48,7 @@ attr_stmt<<(g: GraphData)>>:
 attr_list: LBRACK a=[a_list] RBRACK { getOrElse Map.empty a }
 
 a_list:
-    k=ID ASSIGN v=ID [SEMI { } | COMMA { }] l=[a_list] { Map.add k v (getOrElse Map.empty l) }
+    k=ID ASSIGN v=ID l=[a_list] { Map.add k v (getOrElse Map.empty l) }
 
 node_stmt<<(g: GraphData)>>: n=ID [port { }] a=[attr_list] { addNode g n (getOrElse Map.empty a) |> fst }
 
@@ -61,7 +61,7 @@ edge_rhs<<(d: GraphData * string list list)>>:
 nodes<<(g: GraphData)>>: n=node_id<<g>> { n } | n=subgraph<<g>> { n }
 
 edgeop<<(g: GraphData)>>:
-	EDGE { if g.IsDirected then wrongEdge "--" else () }
+      EDGE { if g.IsDirected then wrongEdge "--" else () }
   | DIEDGE { if not <| g.IsDirected then wrongEdge "->" else () }
 
 node_id<<(g: GraphData)>>: name=ID [port { }] { addNode g name Map.empty }

--- a/src/DotParser/Lexer.fsl
+++ b/src/DotParser/Lexer.fsl
@@ -23,6 +23,7 @@ let keywords =
 let digit = ['0'-'9']
 let whitespace = [' ' '\t' '\r' '\n']
 let id = ['a'-'z' 'A'-'Z' '_'](['a'-'z' 'A'-'Z' '_' '0'-'9'])*|['-']?('.'['0'-'9']+|['0'-'9']+('.'['0'-'9']+)?)
+let lineComment = ['/']['/'][^ '\n']*
 
 rule tokenize = parse
 | whitespace { tokenize lexbuf }
@@ -41,6 +42,7 @@ rule tokenize = parse
          | Some(keyword) -> keyword <| (lexeme lexbuf).ToLower()
          | None -> ID <| lexeme lexbuf }
 | eof  { RNGLR_EOF <| lexeme lexbuf }
+| lineComment{ tokenize lexbuf }
 | _ { failwithf "unexpected input: %s" <| lexeme lexbuf }
 
 and string pos s = parse

--- a/src/DotParser/Lexer.fsl
+++ b/src/DotParser/Lexer.fsl
@@ -45,6 +45,10 @@ rule tokenize = parse
 
 and string pos s = parse
 | "\\\""  { string pos (s + "\"") lexbuf }
+| "\\n"   { string pos (s + "\n") lexbuf }
+| "\\l"   { string pos (s + "\n") lexbuf }
+| "\\r"   { string pos (s + "\n") lexbuf }
+| "\\\\"  { string pos (s + "\\") lexbuf }
 | "\\"    { string pos s lexbuf }
 | "\r"    { string pos s lexbuf }
 | "\""    { s }

--- a/src/DotParser/Lexer.fsl
+++ b/src/DotParser/Lexer.fsl
@@ -33,9 +33,9 @@ rule tokenize = parse
 | '['  { LBRACK <| lexeme lexbuf }
 | ']'  { RBRACK <| lexeme lexbuf }
 | '='  { ASSIGN <| lexeme lexbuf }
-| ';'  { SEMI   <| lexeme lexbuf }
 | ':'  { COLON  <| lexeme lexbuf }
-| ','  { COMMA  <| lexeme lexbuf }
+| ';'  { tokenize lexbuf }
+| ','  { tokenize lexbuf }
 | "--" { EDGE   <| lexeme lexbuf }
 | "->" { DIEDGE <| lexeme lexbuf }
 | id   { match keywords.TryFind((lexeme lexbuf).ToLower()) with


### PR DESCRIPTION
as per https://www.graphviz.org/docs/attr-types/escString
I don’t know F♯ so can’t add test cases at this point but the code works ☺